### PR TITLE
Fixed zero-length byte array allocation.

### DIFF
--- a/Saturn.Backend/Data/Services/SwapperService.cs
+++ b/Saturn.Backend/Data/Services/SwapperService.cs
@@ -2273,9 +2273,9 @@ public sealed class SwapperService : ISwapperService
         if (Rarity != EFortRarity.Common && await _configService.TryGetShouldRarityConvert())
         {
             if (!string.IsNullOrEmpty(option.Status))
-                option.Status = $"All common items are going to be {Rarity.ToString()} and {option.Status}";
+                option.Status = $"All common items are going to be {Rarity} and {option.Status}";
             else
-                option.Status = $"All common items are going to be {Rarity.ToString()}";
+                option.Status = $"All common items are going to be {Rarity}";
             output.Assets.Add(
                 Rarity switch
                 {

--- a/Saturn.Backend/Data/Utils/AnyLength.cs
+++ b/Saturn.Backend/Data/Utils/AnyLength.cs
@@ -157,7 +157,7 @@ namespace Saturn.Backend.Data.Utils
             {
                 if (last + 1 != currentOffset)
                 {
-                    last = last + arr[first + i * 2];
+                    last += arr[first + i * 2];
                 }
                 else
                 {

--- a/Saturn.Backend/Data/Utils/FileUtil.cs
+++ b/Saturn.Backend/Data/Utils/FileUtil.cs
@@ -139,7 +139,8 @@ namespace Saturn.Backend.Data.Utils
             foreach (var color in colorValues)
             {
                 Logger.Log(color.Key);
-                byte[] colorBytes = new byte[] {};
+                // Use 'Array.Empty<T>' when creating an empty array, to avoid unnecessary zero-length array allocations.
+                byte[] colorBytes = Array.Empty<byte>();
                 foreach (var colorValue in color.Value)
                 {
                     colorBytes = Combine(colorBytes, FloatToBytes(colorValue));

--- a/Saturn.Backend/Data/Utils/Logger.cs
+++ b/Saturn.Backend/Data/Utils/Logger.cs
@@ -48,7 +48,7 @@ namespace Saturn.Backend.Data.Utils
             if (typeName.Contains("Service"))
                 typeName = typeName.Replace("Service", "");
 
-            if (typeName.Contains("<"))
+            if (typeName.Contains('<'))
                 typeName = typeName.Split("<")[1].Split(">")[0];
 
 


### PR DESCRIPTION
Initializing a zero-length array leads to an unnecessary memory allocation. Replaced zero-length allocation with 'Array.Empty<byte>()'.