### PR TITLE
Code clean-up

### DIFF
--- a/Saturn.Backend/Data/Models/Items/LeleModel.cs
+++ b/Saturn.Backend/Data/Models/Items/LeleModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 using System.Linq;
 using J = Newtonsoft.Json.JsonPropertyAttribute;
 

--- a/Saturn.Backend/Data/Models/Items/LeleModel.cs
+++ b/Saturn.Backend/Data/Models/Items/LeleModel.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
-using System.Linq;
 using J = Newtonsoft.Json.JsonPropertyAttribute;
 
 namespace Saturn.Backend.Data.Models.Items.Lele

--- a/Saturn.Backend/Data/Models/Items/MeshDefaultModel.cs
+++ b/Saturn.Backend/Data/Models/Items/MeshDefaultModel.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 
 namespace Saturn.Backend.Data.Models.Items
 {
-    public struct MeshDefaultModel
+    // This should be a class given that almost every property in it is a reference type,
+    // except for ECustomHatType which is the only value type
+    public class MeshDefaultModel
     {
         public string HeadSkinColor { get; set; }
         public Dictionary<int, string> HeadMaterials { get; set; }

--- a/Saturn.Backend/Data/Utils/ReadPlugins/DotSaturn.cs
+++ b/Saturn.Backend/Data/Utils/ReadPlugins/DotSaturn.cs
@@ -46,7 +46,8 @@ public class DotSaturn
     
     public static void Write(string filePath, string json)
     {
-        byte[] data = new byte[] { };
+        // Avoid 0 length array allocation
+        byte[] data = Array.Empty<byte>();
         
         using (var md5 = MD5.Create())
         {


### PR DESCRIPTION
There was a compiler error in LeleModel where JObject couldn't be found because 'Newtonsoft.Json.Linq' wasn't imported, avoided 0 length array allocation by using 'Array.Empty<byte>()', and removed unused using in LeleModel.