### PR TITLE
Completely changed how the uninstaller works

### DIFF
--- a/uninst/DirectoryTree.cs
+++ b/uninst/DirectoryTree.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Uninstaller;
+
+internal sealed class DirectoryTree
+{
+    private DirectoryTree(SDirectory baseDirectory)
+    {
+        BaseDirectory = baseDirectory;
+    }
+
+    public static async Task<DirectoryTree> CreateDirectoryTreeAsync(string parentDirectory)
+    {
+        return await Task.Run(async () =>
+        {
+            return new DirectoryTree(await SDirectory.CreateDirectoryAsync(parentDirectory));
+        });
+    }
+
+    /*
+       Directory Tree:
+
+            DRoot
+             |
+            / \
+         ND1   ND2
+          |
+         / \
+     ND1:1  ND1:2
+              |
+             / \
+      ND1:2:1   ND1:2:2
+                   |
+               ND1:2:2:1 // Last node
+        
+    */
+    public SDirectory BaseDirectory { get; }
+
+    private static List<SDirectory> FlattenDirectory(in SDirectory directory)
+    {
+        /*
+            Flattened Directory:
+
+            DRoot
+            ND1
+            ND2
+            ND1:1
+            ND1:2
+            ND1:2:1
+            ND1:2:2
+            ND1:2:2:1
+        */
+        var list = new List<SDirectory> { directory };
+        foreach (var child in directory.Children)
+        {
+            list.AddRange(FlattenDirectory(child));
+        }
+
+        return list;
+    }
+
+    public IEnumerable<SDirectory> GetNestedDirectories()
+    {
+        var directories = FlattenDirectory(BaseDirectory);
+        directories.RemoveAt(0);
+        return directories;
+    }
+
+    public IEnumerable<SDirectory> GetNestedDirectories(string[] partialDirectories, int option = 0)
+    {
+        var dirs = GetNestedDirectories().ToList();
+        var targetDirs = new List<SDirectory>();
+        if (partialDirectories is not null &&
+            partialDirectories != Array.Empty<string>())
+
+        {
+            foreach (var path in partialDirectories)
+            {
+                for (var i = 0; i < dirs.Count(); i++)
+                {
+                    var dir = dirs[i];
+                    if (option == 0 &&
+                        dir.Path.Contains(path))
+                    {
+                        dirs.RemoveAt(i);
+                    }
+                    else if (option == 1 &&
+                             dir.Path.Contains(path))
+                    {
+                        targetDirs.Add(dir);
+                    }
+                }
+            }
+        }
+        else
+        {
+            option = 0;
+        }
+
+        return option == 0 ? dirs : targetDirs;
+    }
+
+    public SDirectory GetNestedDirectory(string partialPath)
+    {
+        var root = BaseDirectory;
+        var directories = FlattenDirectory(root);
+        foreach (var dir in directories)
+        {
+            if (dir.Path.Contains(partialPath))
+            {
+                return dir;
+            }
+        }
+
+        return null;
+    }
+
+    public IEnumerable<SFile> GetFiles(Func<SFile, bool> predicate)
+    {
+        var files = GetFiles();
+        var validFiles = files.Where(predicate);
+        return validFiles;
+    }
+
+    public SFile GetFile(string partialPath)
+    {
+        var stack = new Stack<SDirectory>();
+        stack.Push(BaseDirectory);
+
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            if (node.Children.Any())
+            {
+                foreach (var child in node.Children)
+                {
+                    stack.Push(child);
+                }
+            }
+
+            foreach (var file in node.Files)
+            {
+                if (file.Path.Contains(partialPath))
+                {
+                    return file;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public IEnumerable<SFile> GetFiles() => GetFiles(Array.Empty<string>());
+
+    public IEnumerable<SFile> GetFiles(string[] partialPaths, int option = 0 /* 0 means remove, 1 means only find*/)
+    {
+        var files = new List<SFile>();
+        var stack = new Stack<SDirectory>();
+        stack.Push(BaseDirectory);
+
+        while (stack.Count > 0)
+        {
+            var node = stack.Pop();
+            if (node.Children.Any())
+            {
+                foreach (var child in node.Children)
+                {
+                    stack.Push(child);
+                }
+            }
+
+            foreach (var file in node.Files)
+            {
+                files.Add(file);
+            }
+        }
+
+        var targetFiles = new List<SFile>();
+
+        if (partialPaths is not null &&
+            partialPaths != Array.Empty<string>())
+
+        {
+            foreach (var path in partialPaths)
+            {
+                for (var i = 0; i < files.Count; i++)
+                {
+                    var file = files[i];
+                    if (option == 0 &&
+                        file.Path.Contains(path))
+                    {
+                        files.RemoveAt(i);
+                        break;
+                    }
+                    else if (option == 1 &&
+                             file.Path.Contains(path))
+                    {
+                        targetFiles.Add(file);
+                        break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            option = 0;
+        }
+
+        return option == 0 ? files : targetFiles;
+    }
+}

--- a/uninst/Program.cs
+++ b/uninst/Program.cs
@@ -1,105 +1,115 @@
-﻿using System.Diagnostics;
-using System.Reflection;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Uninstaller;
 
 public static class Program
 {
-    public static void Main(string[] args)
+    public static void Main()
     {
-        Uninstall();
+        Uninstall().GetAwaiter().GetResult();
     }
 
-    internal static void Uninstall()
+    private static async Task Uninstall()
     {
-        try
-        {
-            string[] currentAssembly =
-            {
-                Assembly.GetExecutingAssembly().Location,
-                AppDomain.CurrentDomain.BaseDirectory + $"{typeof(Program).Assembly.GetName().Name}.exe"
-            };
+        var currentAssemblyPath = AppDomain.CurrentDomain.BaseDirectory;
+        var dataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Saturn\\";
 
-            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            var dataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Saturn\\";
-            var cd_AllFiles = GetAllFilesInDirectory(baseDirectory, currentAssembly);
-            foreach (var file in cd_AllFiles)
-            {
-                DeletePath(file, 1);
-            }
-            var cd_AllDirectories = GetAllSubDirectories(baseDirectory);
-            cd_AllDirectories.Reverse();
-            foreach (var directory in cd_AllDirectories)
-            {
-                DeletePath(directory, 0);
-            }
-            var data_AllFiles = GetAllFilesInDirectory(dataPath);
-            foreach (var file in data_AllFiles)
-            {
-                DeletePath(file, 1);
-            }
-            var data_AllDirectories = GetAllSubDirectories(dataPath);
-            data_AllDirectories.Reverse();
-            foreach (var directory in data_AllDirectories)
-            {
-                DeletePath(directory, 0);
-            }
-            foreach (var file in currentAssembly)
-            {
-                Process.Start("cmd.exe", $"/C choice /C Y /N /D Y /T 3 & Del {file}");
-            }
-        }
-        catch (Exception e)
+        var currentDirectctoryTree = await DirectoryTree.CreateDirectoryTreeAsync(currentAssemblyPath);
+        var plugins = currentDirectctoryTree.GetFiles(x => x.Path.Contains(".json") &&
+                                             x.FileContents.Contains("AssetPath")); // Gets all plugins. All plugin files should contain a part that says "Appdata"
+        foreach (var plugin in plugins)
         {
-            Console.WriteLine(e.ToString());
-            Console.ReadKey();
+            plugin.Delete();
+        }
+
+        var assemblyFileNames = new string[] { "uninst.exe", "uninst.dll" }; // Essentially the partial paths of the assembly.
+
+        var targetFiles = new string[] { "Saturn.exe", "oo2core_9_win64.dll", "uninst.r", "uninst.p", "uninst.deps" };
+        var targetDirectories = new string[] { "wwwroot", "Saturn.exe.WebView2" };
+
+        await DeleteDirectoryTree(currentDirectctoryTree, targetFiles, targetDirectories);
+
+        var adDirectoryTree = await DirectoryTree.CreateDirectoryTreeAsync(dataPath);
+        var adPlugins = adDirectoryTree.GetFiles(x => x.Path.Contains(".json") &&
+                                                 x.FileContents.Contains("AssetPath")); // Check if this directory contains any plugins
+
+        foreach (var plugin in adPlugins)
+        {
+            plugin.Delete();
+        }
+
+        await DeleteDirectoryTree(adDirectoryTree, null, null);
+        
+        var assemblyFiles = new List<SFile>();
+        foreach (var name in assemblyFileNames)
+        {
+            assemblyFiles.Add(currentDirectctoryTree.GetFile(name)); // Get the current assembly, and it's executing parent
+        }
+
+        // This command force deletes this assembly.
+        var command = "/C choice /C Y /N /D Y /T 3 & Del ";
+        foreach (var file in assemblyFiles)
+        {
+            Process.Start("cmd.exe", command + file.Path);
         }
     }
 
-    internal static List<string> GetAllSubDirectories(string directory)
+    private static async Task DeleteDirectoryTree(DirectoryTree tree, string[] partialFilePaths, string[] partialDirectoryPaths)
     {
-        var subDirectories = new List<string>();
-        var level = Directory.GetDirectories(directory).ToList();
-        subDirectories.AddRange(level);
-        foreach (var dir in level)
+        if (!Directory.Exists(tree.BaseDirectory.Path))
         {
-            subDirectories.AddRange(GetAllSubDirectories(dir));
+            return;
         }
 
-        return subDirectories;
-    }
-
-    internal static List<string> GetAllFilesInDirectory(string directory, string[] exclude = null)
-    {
-        var files = new List<string>();
-        files.AddRange(Directory.GetFiles(directory));
-        if (exclude != null)
+        var files = tree.GetFiles(partialFilePaths, 1).ToList();
+        if (partialDirectoryPaths is not null)
         {
-            foreach (var file in exclude)
+            foreach (var directory in partialDirectoryPaths)
             {
-                files.Remove(file);
+                var path = tree.GetNestedDirectory(directory).Path;
+                if (!Directory.Exists(path))
+                {
+                    continue;
+                }
+                else
+                {
+                    var dTree = await DirectoryTree.CreateDirectoryTreeAsync(tree.GetNestedDirectory(directory).Path);
+                    files.AddRange(dTree.GetFiles());
+                }
             }
         }
 
-        var subDirs = GetAllSubDirectories(directory);
-        foreach (var dir in subDirs)
+        foreach (var file in files)
         {
-            files.AddRange(GetAllFilesInDirectory(dir, null));
+            file.Delete();
         }
 
-        return files;
-    }
-
-    internal static void DeletePath(string path, int type)
-    {
-        if (type == 0 &&
-            Directory.Exists(path))
+        if (partialDirectoryPaths is not null)
         {
-            Directory.Delete(path);
+            foreach (var directory in partialDirectoryPaths)
+            {
+                var path = tree.GetNestedDirectory(directory).Path;
+                if (!Directory.Exists(path))
+                {
+                    continue;
+                }
+                else
+                {
+                    tree.GetNestedDirectory(directory).Delete();
+                }
+            }
         }
-        else if (type == 1 &&
-                 File.Exists(path))
+        else
         {
-            File.Delete(path);
+            foreach (var child in tree.BaseDirectory.Children)
+            {
+                child.Delete();
+            }
         }
     }
 }

--- a/uninst/SBase.cs
+++ b/uninst/SBase.cs
@@ -1,0 +1,8 @@
+﻿namespace Uninstaller;
+
+internal abstract class SBase
+{
+    public abstract void Delete();
+
+    public abstract string Path { get; }
+}

--- a/uninst/SDirectory.cs
+++ b/uninst/SDirectory.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Uninstaller;
+
+internal sealed class SDirectory
+    : SBase
+{
+    private SDirectory(string directoryPath)
+    {
+        Path = directoryPath;
+        if (!Directory.Exists(Path))
+        {
+            Children = Enumerable.Empty<SDirectory>();
+            Files = Enumerable.Empty<SFile>();
+            return;
+        }
+
+        var nestedDirectories = Directory.GetDirectories(directoryPath);
+        var children = new List<SDirectory>();
+        foreach (var nestedDirectory in nestedDirectories)
+            children.Add(new SDirectory(nestedDirectory));
+
+        Children = children;
+        var files = Directory.GetFiles(directoryPath);
+        var wndFiles = new List<SFile>();
+        foreach (var file in files)
+            wndFiles.Add(new SFile(file));
+
+        Files = wndFiles;
+    }
+
+    public override string Path { get; }
+    public IEnumerable<SDirectory> Children { get; set; }
+    public IEnumerable<SFile> Files { get;  set; }
+
+    private IEnumerable<SDirectory> Flatten(SDirectory directory)
+    {
+        var list = new List<SDirectory> { directory };
+        foreach (var child in directory.Children)
+        {
+            list.AddRange(Flatten(child));
+        }
+
+        return list;
+    }
+
+    public override void Delete()
+    {
+        Directory.Delete(Path, true);
+    }
+
+    public static async Task<SDirectory> CreateDirectoryAsync(string directoryPath)
+    {
+        return await Task.Run(() =>
+        {
+            return new SDirectory(directoryPath);
+        });
+    }
+}

--- a/uninst/SFile.cs
+++ b/uninst/SFile.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace Uninstaller;
+
+internal sealed class SFile
+    : SBase
+{
+    public SFile(string filePath)
+    {
+        FileContents = File.ReadAllText(filePath);
+        Path = filePath;
+    }
+
+    public string FileContents { get; }
+    public override string Path { get; }
+
+    public override void Delete()
+    {
+        File.Delete(Path);
+    }
+}

--- a/uninst/uninst.csproj
+++ b/uninst/uninst.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Completely changed how the uninstaller works. The uninstaller now targets Saturn specific files, like plugins, and appdata. The uninstaller used to delete every file in it's parent folder which could cause a lot of damage if the user were to run it out of a specific folder for Saturn.

Implemented a custom file system, so there may still be some issues with it, but it seems to work for the most part.