### PR TITLE
Fixed an error where the static property just didn't exist, and added…

### DIFF
--- a/CUE4Parse/CUE4Parse/SaturnData.cs
+++ b/CUE4Parse/CUE4Parse/SaturnData.cs
@@ -9,6 +9,7 @@ public class SaturnData
     public static string UAssetPath { get; set; }
     public static ZLIBBlock? Block { get; set; } = null;
     public static string SearchCID { get; set; } = "NOCID";
+    public static int Parition { get; set; } = 0;
 }
 
 public class ZLIBBlock

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/AxetralFromSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/AxetralFromSwap.cs
@@ -28,7 +28,7 @@ internal sealed class AxetralFormSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/BankShotsSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/BankShotsSwap.cs
@@ -22,7 +22,7 @@ internal sealed class BankShotsSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 2 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/BladeOfTheWaningMoonSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/BladeOfTheWaningMoonSwap.cs
@@ -22,7 +22,7 @@ internal sealed class BladeOfTheWaningMoonSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/CombatKnife.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/CombatKnife.cs
@@ -22,7 +22,7 @@ internal sealed class CombatKnifeSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/FrozenAxeSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/FrozenAxeSwap.cs
@@ -28,7 +28,7 @@ internal class FrozenAxeSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 2 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/GrootsSapAxesSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/GrootsSapAxesSwap.cs
@@ -22,7 +22,7 @@ internal sealed class GrootsSapAxesSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/GumBrawlerSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/GumBrawlerSwap.cs
@@ -23,7 +23,7 @@ internal sealed class GumBrawlerSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 2 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/HackAndSmashSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/HackAndSmashSwap.cs
@@ -22,7 +22,7 @@ internal sealed class HackAndSmashSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 2 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/HandOfLightningSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/HandOfLightningSwap.cs
@@ -22,7 +22,7 @@ internal sealed class HandOfLightningSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/IOIradicatorSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/IOIradicatorSwap.cs
@@ -22,7 +22,7 @@ internal sealed class IOIradicatorSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/LeviathanAxeSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/LeviathanAxeSwap.cs
@@ -28,7 +28,7 @@ internal sealed class LeviathanAxeSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/MayhemScytheSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/MayhemScytheSwap.cs
@@ -22,7 +22,7 @@ internal sealed class MayhemScytheSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 2 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/PhantasmicPulseSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/PhantasmicPulseSwap.cs
@@ -22,7 +22,7 @@ internal sealed class PhantasmicPulseSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/ShadowSlicerSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/ShadowSlicerSwap.cs
@@ -31,7 +31,7 @@ internal sealed class ShadowSlicerSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/SnowySwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/SnowySwap.cs
@@ -22,7 +22,7 @@ internal sealed class SnowySwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 2 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/SwapOptions/Pickaxes/TorinsLightbladeSwap.cs
+++ b/Saturn.Backend/Data/SwapOptions/Pickaxes/TorinsLightbladeSwap.cs
@@ -22,7 +22,7 @@ internal sealed class TorinsLightbladeSwap : PickaxeSwap
                     new SaturnSwap()
                     {
                         Search = System.Convert.ToBase64String(new byte[] { 255, 255, 255, 3 }),
-                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)rarityEnum }),
+                        Replace = System.Convert.ToBase64String(new byte[] { 255, 255, 255, (byte)RarityEnum }),
                         Type = SwapType.Property
                     },
                     new SaturnSwap()

--- a/Saturn.Backend/Data/Utils/Swaps/AbstractGeneration.cs
+++ b/Saturn.Backend/Data/Utils/Swaps/AbstractGeneration.cs
@@ -8,7 +8,7 @@ using Saturn.Backend.Data.Models.FortniteAPI;
 
 namespace Saturn.Backend.Data.Utils.Swaps;
 
-internal class AbstractGeneration
+internal abstract class AbstractGeneration
 {
     /// <summary>
     /// Sets the item type the class will use and creates the base configuration directory.

--- a/Saturn.Backend/Data/Utils/Swaps/AbstractSwap.cs
+++ b/Saturn.Backend/Data/Utils/Swaps/AbstractSwap.cs
@@ -6,6 +6,14 @@ namespace Saturn.Backend.Data.Utils.Swaps;
 
 internal abstract class AbstractSwap
 {
+    public AbstractSwap(string name, string rarity, string icon, EFortRarity rarityEnum = EFortRarity.Common)
+    {
+        Name = name;
+        Rarity = rarity;
+        Icon = icon;
+        this.RarityEnum = rarityEnum;
+    }
+    
     public virtual SaturnOption ToSaturnOption()
     {
         return new SaturnOption()
@@ -17,14 +25,6 @@ internal abstract class AbstractSwap
         };
     }
 
-    public AbstractSwap(string name, string rarity, string icon, EFortRarity rarityEnum = EFortRarity.Common)
-    {
-        Name = name;
-        Rarity = rarity;
-        Icon = icon;
-        this.rarityEnum = rarityEnum;
-    }
-
     public virtual string Name { get; }
 
     public virtual string Rarity { get; }
@@ -32,5 +32,5 @@ internal abstract class AbstractSwap
     public virtual string Icon { get; }
 
     public abstract List<SaturnAsset> Assets { get; }
-    public virtual EFortRarity rarityEnum { get; set; }
+    public virtual EFortRarity RarityEnum { get; set; }
 }

--- a/Saturn.Backend/Saturn.Backend.csproj
+++ b/Saturn.Backend/Saturn.Backend.csproj
@@ -148,4 +148,8 @@
         </Content>
     </ItemGroup>
 
+    <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+      <Exec Command="dotnet restore" />
+    </Target>
+
 </Project>


### PR DESCRIPTION
Fixed an error in SaturnData where the static property 'Parition' didn't exist. Also I added a pre-build event 'dotnet restore' because I've noticed that every time I clone the main SaturnSwapper repo, I always get a few 'Metadata file missing' errors, and I assume it has to do with the way github clones repos. To combat this I added the pre-build event 'dotnet restore'.

See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-restore to learn how dotnet restore works