### PR TITLE
fixed lobby swaps not loading for some people.

### DIFF
--- a/Saturn.Backend/Pages/Index.razor
+++ b/Saturn.Backend/Pages/Index.razor
@@ -1090,8 +1090,6 @@
 
     private async Task GoToLobbyCosmetics(ItemType type)
     {
-        if (_halted) return;
-        _halted = true;
         currentType = type;
         _saturnState = SaturnState.S_Loading;
 


### PR DESCRIPTION
removed halted for private async Task GoToLobbyCosmetics, for some reason this stopped people from being able to use lobby swaps (the reason it wouldn't load for some people) I tested it and it works after removing the 2 lines.